### PR TITLE
Add functionality for ref-qualified methods

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     long_description=long_description,
     long_description_content_type='text/markdown',
     license='GLP-3.0-or-later',
-    version='0.6.0-beta1',
+    version='0.6.0-beta2',
     packages=['drmock'],
     package_dir={'': 'src'},
     entry_points={

--- a/src/drmock/overload.py
+++ b/src/drmock/overload.py
@@ -60,19 +60,18 @@ class Overload:
         """Generate the overload's template getter method."""
         f = self._methods[0]  # Representative of the overload.
         result = types.Method('f')  # Use temporary dummy name for initialization!
-        result.template = types.TemplateDecl([PARAMETER_PACK])
         result.name = f.mangled_name()
         result.return_type = types.Type.from_spelling('auto &')
-
-        # Create arguments for dispatch call.
-        dispatch = result.template.get_args()
 
         # If all methods have the same parameter types, then these must
         # automatically be passed as arguments to the dispatch call.
         # NOTE When using strings, spelling differences between equal
         # types (``T *`` vs. ``T*``) can cause this part to malfunction.
         if not self.is_overload():  # all(f.params == each.params for each in self._methods):
-            dispatch.extend(f.params)
+            dispatch = f.params[:]
+        else:
+            result.template = types.TemplateDecl([PARAMETER_PACK])
+            dispatch = result.template.get_args()
 
         # If all methods are const qualified, then the const qualifier
         # must automatically be passed to the dispatch method.

--- a/src/drmock/overload.py
+++ b/src/drmock/overload.py
@@ -18,6 +18,8 @@ SHARED_PTR_PREFIX = 'METHODS_DRMOCK_'
 STATE_OBJECT_NAME = 'STATE_OBJECT_DRMOCK_'
 CONST_ENUM = 'drmock::Const'
 VOLATILE_ENUM = 'drmock::Volatile'
+LVALUE_ENUM = 'drmock::LValueRef'
+RVALUE_ENUM = 'drmock::RValueRef'
 TYPE_CONTAINER = 'TypeContainer'
 PARAMETER_PACK = '... DRMOCK_Ts'
 
@@ -77,6 +79,10 @@ class Overload:
         # must automatically be passed to the dispatch method.
         if all(each.const for each in self._methods):
             dispatch.append(CONST_ENUM)
+        if all(each.lvalue for each in self._methods):
+            dispatch.append(LVALUE_ENUM)
+        if all(each.rvalue for each in self._methods):
+            dispatch.append(RVALUE_ENUM)
 
         result.body = f'return {f.mangled_name()}_dispatch(' + TYPE_CONTAINER + \
             utils.template(dispatch) + '{});'
@@ -116,6 +122,10 @@ class Overload:
                 template_args.append(types.Type(CONST_ENUM))
             if f.volatile:
                 template_args.append(types.Type(VOLATILE_ENUM))
+            if f.lvalue:
+                template_args.append(types.Type(LVALUE_ENUM))
+            if f.rvalue:
+                template_args.append(types.Type(RVALUE_ENUM))
             dispatch.params = [types.Type(TYPE_CONTAINER + utils.template(template_args))]
             dispatch.body = 'return *' + _shared_ptr_name(f.mangled_name(), i) + ';'
             dispatch.access = 'private'
@@ -179,6 +189,10 @@ def _generate_access(f: types.Method, overload: bool) -> str:
             template_args.append(CONST_ENUM)
         if f.volatile:
             template_args.append(VOLATILE_ENUM)
+        if f.lvalue:
+            template_args.append(LVALUE_ENUM)
+        if f.rvalue:
+            template_args.append(RVALUE_ENUM)
         result = MOCK_OBJECT_NAME + '.template ' + f.mangled_name() \
             + utils.template(template_args) + '()'
     else:

--- a/src/drmock/types.py
+++ b/src/drmock/types.py
@@ -442,6 +442,8 @@ class Method:
         template: The method's template declaration (if available)
         const: Indicates if the method is const-qualified
         volatile: Indicates if the method is volatile-qualified
+        lvalue: Indicates if the method is lvalue qualified
+        rvalue: Indicates if the method is rvalue qualified
         virtual: Indicates if the method is virtual
         pure_virtual: Indicates if the method is pure virtual
         override: Indicates if the method has the ``override`` specifier
@@ -465,6 +467,8 @@ class Method:
     template: Optional[TemplateDecl] = None
     const: bool = False
     volatile: bool = False
+    lvalue: bool = False
+    rvalue: bool = False
     virtual: bool = False
     pure_virtual: bool = False
     override: bool = False
@@ -493,6 +497,8 @@ class Method:
         result += f'({params})'
         result += self.const * ' const'
         result += self.volatile * ' volatile'
+        result += self.lvalue * '&'
+        result += self.rvalue * '&&'
         result += self.noexcept * ' noexcept'
         result += self.override * ' override'  # This must always be last!
         if self.body:
@@ -589,6 +595,10 @@ class Method:
             f.override = True
         if 'volatile' in keywords:
             f.volatile = True
+        if '&' in keywords:
+            f.lvalue = True
+        if '&&' in keywords:
+            f.rvalue = True
 
         # Const qualifiers, virtual keywords, and exception
         # specifications can be obtained using python clang.

--- a/tests/test_overload.py
+++ b/tests/test_overload.py
@@ -69,8 +69,8 @@ class TestOverload:
          types.Method(
              name='foo',
              return_type=types.Type(inner='auto', lvalue_ref=True),
-             template=types.TemplateDecl(['... DRMOCK_Ts']),
-             body='return foo_dispatch(TypeContainer<DRMOCK_Ts ..., int, float, drmock::Const>{});')),
+             template=None,
+             body='return foo_dispatch(TypeContainer<int, float, drmock::Const>{});')),
         ('Foo',
          [{'mangled_name': mock.Mock(return_value='foo'), 'params': [], 'const': True},
           {'mangled_name': mock.Mock(return_value='foo'), 'params': ['int'], 'const': True}],

--- a/tests/test_overload.py
+++ b/tests/test_overload.py
@@ -57,23 +57,23 @@ class TestOverload:
 
     @pytest.mark.parametrize('parent, kwargs, expected', [
         ('Foo',
-         [{'mangled_name': mock.Mock(return_value='foo'), 'params': [], 'const': True},
-          {'mangled_name': mock.Mock(return_value='foo'), 'params': ['int'], 'const': False}],
+         [{'mangled_name': mock.Mock(return_value='foo'), 'params': [], 'const': True, 'lvalue': False, 'rvalue': False},
+          {'mangled_name': mock.Mock(return_value='foo'), 'params': ['int'], 'const': False, 'lvalue': False, 'rvalue': False}],
          types.Method(name='foo',
                       return_type=types.Type(inner='auto', lvalue_ref=True),
                       template=types.TemplateDecl(['... DRMOCK_Ts']),
                       body='return foo_dispatch(TypeContainer<DRMOCK_Ts ...>{});')),
         ('Foo',
          [{'mangled_name': mock.Mock(return_value='foo'), 'params': [
-             'int', 'float'], 'const': True}],
+             'int', 'float'], 'const': True, 'lvalue': False, 'rvalue': False}],
          types.Method(
              name='foo',
              return_type=types.Type(inner='auto', lvalue_ref=True),
              template=None,
              body='return foo_dispatch(TypeContainer<int, float, drmock::Const>{});')),
         ('Foo',
-         [{'mangled_name': mock.Mock(return_value='foo'), 'params': [], 'const': True},
-          {'mangled_name': mock.Mock(return_value='foo'), 'params': ['int'], 'const': True}],
+         [{'mangled_name': mock.Mock(return_value='foo'), 'params': [], 'const': True, 'lvalue': False, 'rvalue': False},
+          {'mangled_name': mock.Mock(return_value='foo'), 'params': ['int'], 'const': True, 'lvalue': False, 'rvalue': False}],
          types.Method(name='foo',
                       return_type=types.Type(inner='auto', lvalue_ref=True),
                       template=types.TemplateDecl(['... DRMOCK_Ts']),
@@ -82,6 +82,9 @@ class TestOverload:
     def test_generate_getter(self, parent, kwargs, expected, mocker):
         methods = [mocker.Mock(**each) for each in kwargs]
         collection = overload.Overload(parent, methods)
+        for each in methods:
+            print(each.lvalue)
+            print(each.rvalue)
         assert collection.generate_getter() == expected
 
     @pytest.mark.parametrize('full_name, kwargs, expected', [
@@ -143,11 +146,15 @@ class TestOverload:
          [{'mangled_name': mock.Mock(return_value='foo'),
            'params': [],
            'const': True,
-           'volatile': False},
+           'volatile': False,
+           'lvalue': False,
+           'rvalue': False},
           {'mangled_name': mock.Mock(return_value='foo'),
            'params': ['int'],
            'const': False,
-           'volatile': False}],
+           'volatile': False,
+           'lvalue': False,
+           'rvalue': False,}],
          [types.Method(name='foo_dispatch',
                        params=[types.Type(inner='TypeContainer<drmock::Const>')],
                        return_type=types.Type(inner='auto', lvalue_ref=True),
@@ -162,7 +169,9 @@ class TestOverload:
          [{'mangled_name': mock.Mock(return_value='foo'),
            'params': ['int', 'float'],
            'const': True,
-           'volatile': False}],
+           'volatile': False,
+           'lvalue': False,
+           'rvalue': False,}],
          [types.Method(name='foo_dispatch',
                        params=[types.Type(inner='TypeContainer<int, float, drmock::Const>')],
                        return_type=types.Type(inner='auto', lvalue_ref=True),
@@ -172,11 +181,15 @@ class TestOverload:
          [{'mangled_name': mock.Mock(return_value='baz'),
            'params': [],
            'const': True,
-           'volatile': False},
+           'volatile': False,
+           'lvalue': False,
+           'rvalue': False,},
           {'mangled_name': mock.Mock(return_value='baz'),
            'params': ['int'],
            'const': True,
-           'volatile': False}],
+           'volatile': False,
+           'lvalue': False,
+           'rvalue': False,}],
          [types.Method(name='baz_dispatch',
                        params=[types.Type(inner='TypeContainer<drmock::Const>')],
                        return_type=types.Type(inner='auto', lvalue_ref=True),
@@ -297,9 +310,9 @@ class TestOverload:
          ['mock.foo_mangled().parent(this);']),
         (True,
          [{'mangled_name': mock.Mock(return_value='foo_mangled'),
-           'params': ['int', 'float', 'double'], 'const': True, 'volatile': False},
+           'params': ['int', 'float', 'double'], 'const': True, 'volatile': False, 'lvalue': False, 'rvalue': False,},
           {'mangled_name': mock.Mock(return_value='foo_mangled'),
-           'params': ['std::unordered_map<int, float>'], 'const': False, 'volatile': False}],
+           'params': ['std::unordered_map<int, float>'], 'const': False, 'volatile': False, 'lvalue': False, 'rvalue': False,}],
          ['mock.template foo_mangled<int, float, double, drmock::Const>().parent(this);',
           'mock.template foo_mangled<std::unordered_map<int, float>>().parent(this);']),
     ])

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -264,7 +264,15 @@ class TestMethod:
          types.Method(name='f', params=[types.Type(inner=types.Type(inner='T', const=True),
                                                    pointer=True,
                                                    const=True)],
-                      virtual=True, pure_virtual=True))
+                      virtual=True, pure_virtual=True)),
+        (
+            'class _ { virtual void f() const& = 0; };',
+            types.Method(name='f', params=[], const=True, lvalue=True, pure_virtual=True, virtual=True)
+        ),
+        (
+            'class _ { virtual void f() && noexcept = 0; };',
+            types.Method(name='f', params=[], noexcept=True, rvalue=True, pure_virtual=True, virtual=True)
+        ),
     ])
     def test_from_node(self, set_library_file, source, expected):
         root = translator.translate(PATH, source, ['--std=c++11'])


### PR DESCRIPTION
Change getter and dispatch methods of the mock object to provide functionality for reference-qualified methods. The main framework must now implemented two new qualifier structs, `drmock::LValueRef` and `drmock::RValueRef`.